### PR TITLE
Use semantic layout with centered container

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,11 @@
 *{box-sizing:border-box;margin:0;padding:0}
 body{
   font-family:system-ui,-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
-  background:var(--bg);color:var(--txt);line-height:1.45;padding:1rem;
+  background:var(--bg);color:var(--txt);line-height:1.45;
 }
 h1{margin:.2rem 0 .6rem}
 h2{margin-bottom:.5rem}
+.container{max-width:900px;margin:0 auto;padding:1rem}
 section{
   background:var(--card);padding:1rem 1.1rem;border-radius:8px;
   box-shadow:0 2px 4px rgba(0,0,0,.05);margin-bottom:1.6rem
@@ -77,6 +78,7 @@ button:hover{opacity:.9}
 <link rel="manifest"></head>
 <body>
 
+<header class="container">
 <h1>Dishwasher Troubleshooting</h1>
 
 <div id="essBar">
@@ -88,6 +90,9 @@ button:hover{opacity:.9}
     Water Hardness
   </a>
 </div>
+</header>
+
+<main class="container">
 
 <section>
   <h2>1. Quick Symptom Lookup</h2>
@@ -125,6 +130,8 @@ button:hover{opacity:.9}
     <li><em>Loading tests...</em></li>
   </ul>
 </section>
+
+</main>
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- nest title and essential links within a semantic `<header>`
- group core troubleshooting sections under a `<main>` container
- centralize layout via new `.container` class for consistent width

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e1495bc208321a4618c28f8943b64