### PR TITLE
Handle clipboard copy errors gracefully

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -137,7 +137,10 @@ document.addEventListener('DOMContentLoaded', () => {
       txt += '\n--- Symptom ---\n';
       txt += symptomSel.value ? `${symptomSel.value}\n` : 'None selected\n';
       txt += symptomResult.textContent.trim() ? '\n' + symptomResult.textContent.trim() : '';
-      navigator.clipboard.writeText(txt).then(() => alert('Summary copied!'));
+      navigator.clipboard
+        .writeText(txt)
+        .then(() => alert('Summary copied!'))
+        .catch(() => alert('Could not copy summary. Please copy manually.'));
     });
     ['mMake', 'mModel'].forEach(id => {
       const el = $('#' + id);


### PR DESCRIPTION
## Summary
- Show user-friendly message when copy-to-clipboard fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e1c2df14c8321b32c0facd6b99961