### PR TITLE
Enhance checklist accessibility and styling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -46,15 +46,19 @@ button:hover{opacity:.9}
   border:1px solid var(--sep);border-radius:6px;padding:.8rem .9rem;
   margin-bottom:.9rem;display:flex;flex-wrap:wrap;align-items:center
 }
-.qcard p{flex:1 1 260px;margin:.25rem 0;font-weight:500}
+.qcard legend{flex:1 1 260px;margin:.25rem 0;font-weight:500}
 .toggle{display:inline-flex;border-radius:20px;overflow:hidden;margin-left:auto}
 .toggle input{display:none}
 .toggle label{
-  padding:.34rem .95rem;font-size:.92rem;cursor:pointer;transition:opacity .15s;opacity:.4
+  padding:.34rem .95rem;font-size:.92rem;cursor:pointer;transition:opacity .15s;opacity:.4;
+  display:flex;align-items:center;gap:.25rem
 }
+.toggle label:focus{outline:2px solid var(--accent);outline-offset:2px}
 .toggle input:checked+label{opacity:1}
 .toggle .yes{background:var(--yes);color:#fff}
 .toggle .no {background:var(--no);color:#fff}
+.icon-check::before{content:'\2714';margin-right:.25rem}
+.icon-cross::before{content:'\2716';margin-right:.25rem}
 .note{flex:1 1 100%;margin:.4rem 0 0;font-size:.85rem;color:var(--accent)}
 .mm-row{display:flex;gap:.6rem;flex-wrap:wrap;margin-bottom:1rem}
 .mm-row div{flex:1 1 200px}

--- a/index.html
+++ b/index.html
@@ -39,14 +39,14 @@
     <div><label for="mModel">Machine model</label><input id="mModel" autocomplete="off"></div>
   </div>
   <template id="toggleTemplate">
-    <div class="qcard">
-      <p></p>
+    <fieldset class="qcard">
+      <legend></legend>
       <div class="toggle">
-        <input type="radio"><label class="yes">Yes</label>
-        <input type="radio"><label class="no">No</label>
+        <input type="radio"><label class="yes" aria-label="Yes" tabindex="0"><span class="icon-check"></span> Yes</label>
+        <input type="radio"><label class="no" aria-label="No" tabindex="0"><span class="icon-cross"></span> No</label>
       </div>
       <div class="note" hidden></div>
-    </div>
+    </fieldset>
   </template>
   <div id="toggleHolder"><p><em>Loading questions...</em></p></div>
   <div id="checklistResult" class="result"></div>
@@ -126,24 +126,36 @@ document.addEventListener('DOMContentLoaded', () => {
     const tpl = $('#toggleTemplate').content;
     DATA.questions.forEach((q, i) => {
       const node = document.importNode(tpl, true);
-      const [p, noteDiv] = [node.querySelector('p'), node.querySelector('.note')];
+      const [legend, noteDiv] = [node.querySelector('legend'), node.querySelector('.note')];
       const [yIn, nIn] = node.querySelectorAll('input');
       const [yLbl, nLbl] = [node.querySelector('.yes'), node.querySelector('.no')];
-      
-      p.textContent = `${i + 1}. ${q.text}`;
+
+      legend.textContent = `${i + 1}. ${q.text}`;
       yIn.id = `${q.key}Y`; nIn.id = `${q.key}N`;
+      yLbl.id = `${yIn.id}-lbl`; nLbl.id = `${nIn.id}-lbl`;
       yIn.name = nIn.name = q.key;
       yIn.value = 'Yes'; nIn.value = 'No';
       yLbl.setAttribute('for', yIn.id); nLbl.setAttribute('for', nIn.id);
-      
+      yIn.setAttribute('aria-labelledby', yLbl.id);
+      nIn.setAttribute('aria-labelledby', nLbl.id);
+
+      [yLbl, nLbl].forEach(lbl => {
+        lbl.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            document.getElementById(lbl.getAttribute('for')).click();
+          }
+        });
+      });
+
       if (q.note) {
         noteDiv.textContent = q.note;
         noteDiv.hidden = false;
       }
-      
+
       const saved = ls.get('toggle_' + q.key) || 'Yes';
       if (saved === 'No') nIn.checked = true; else yIn.checked = true;
-      
+
       checklistHolder.appendChild(node);
     });
   };


### PR DESCRIPTION
## Summary
- Wrap dynamic checklist questions in `<fieldset>` with `<legend>` text.
- Add icon-enhanced Yes/No labels, keyboard focus styles, and unique IDs with aria attributes.
- Introduce keyboard activation for labels and focus styling in CSS.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2a02a014832185e88ea980df4a90