### PR TITLE
Add live JSON preview with collapse toggle

### DIFF
--- a/ContentsEditor.html
+++ b/ContentsEditor.html
@@ -152,6 +152,17 @@
                 </div>
             </section>
 
+            <!-- Preview Section -->
+            <section id="preview" class="card">
+                <div class="card-header flex justify-between items-center">
+                    <h2>JSON Preview</h2>
+                    <button id="togglePreview" class="btn btn-secondary text-sm py-2 px-3">Show Preview</button>
+                </div>
+                <div id="previewBody" class="card-body hidden">
+                    <pre id="jsonPreview" class="whitespace-pre-wrap break-all"></pre>
+                </div>
+            </section>
+
             <!-- Step 2: Download -->
             <div class="card">
                 <div class="card-header">Step 2: Save and Download</div>
@@ -166,7 +177,7 @@
     <!-- Templates for dynamic items -->
     <template id="symptomTemplate">
         <div class="item-card">
-            <div class="delete-btn" onclick="this.parentElement.remove()">&#x2715;</div>
+            <div class="delete-btn" onclick="removeItem(this)">&#x2715;</div>
             <div class="item-card-body grid grid-cols-1 gap-4">
                 <div>
                     <label>Symptom Name</label>
@@ -186,7 +197,7 @@
 
     <template id="questionTemplate">
         <div class="item-card">
-            <div class="delete-btn" onclick="this.parentElement.remove()">&#x2715;</div>
+            <div class="delete-btn" onclick="removeItem(this)">&#x2715;</div>
             <div class="item-card-body grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="md:col-span-2">
                     <label>Question Text</label>
@@ -206,7 +217,7 @@
 
     <template id="testTemplate">
         <div class="item-card">
-            <div class="delete-btn" onclick="this.parentElement.remove()">&#x2715;</div>
+            <div class="delete-btn" onclick="removeItem(this)">&#x2715;</div>
             <div class="item-card-body grid grid-cols-1 gap-4">
                 <div>
                     <label>Test Title</label>
@@ -233,6 +244,9 @@
             const addSymptomBtn = document.getElementById('addSymptom');
             const addQuestionBtn = document.getElementById('addQuestion');
             const addTestBtn = document.getElementById('addTest');
+            const previewBody = document.getElementById('previewBody');
+            const jsonPreview = document.getElementById('jsonPreview');
+            const togglePreviewBtn = document.getElementById('togglePreview');
             
             const symptomsContainer = document.getElementById('symptomsContainer');
             const questionsContainer = document.getElementById('questionsContainer');
@@ -249,6 +263,11 @@
             addQuestionBtn.addEventListener('click', () => addQuestion());
             addTestBtn.addEventListener('click', () => addTest());
             downloadBtn.addEventListener('click', generateAndDownloadJson);
+            togglePreviewBtn.addEventListener('click', () => {
+                previewBody.classList.toggle('hidden');
+                togglePreviewBtn.textContent = previewBody.classList.contains('hidden') ? 'Show Preview' : 'Hide Preview';
+            });
+            editor.addEventListener('input', updatePreview);
 
             // --- File Handling ---
             function handleFileUpload(event) {
@@ -261,6 +280,7 @@
                         const data = JSON.parse(e.target.result);
                         populateForms(data);
                         editor.classList.remove('hidden');
+                        updatePreview();
                     } catch (err) {
                         alert('Error: Invalid JSON file. Please check the file and try again.');
                         console.error(err);
@@ -300,6 +320,7 @@
                 clone.querySelector('.symptom-causes').value = causes;
                 clone.querySelector('.symptom-actions').value = actions;
                 symptomsContainer.appendChild(clone);
+                updatePreview();
             }
 
             function addQuestion(text = '', key = '', note = '') {
@@ -308,6 +329,7 @@
                 clone.querySelector('.question-key').value = key;
                 clone.querySelector('.question-note').value = note;
                 questionsContainer.appendChild(clone);
+                updatePreview();
             }
 
             function addTest(title = '', description = '', check = '') {
@@ -316,17 +338,21 @@
                 clone.querySelector('.test-description').value = description;
                 clone.querySelector('.test-check').value = check;
                 testsContainer.appendChild(clone);
+                updatePreview();
             }
-            
-            // --- JSON Generation and Download ---
-            function generateAndDownloadJson() {
+
+            function removeItem(el) {
+                el.parentElement.remove();
+                updatePreview();
+            }
+
+            function serializeData() {
                 const finalData = {
                     symptoms: {},
                     questions: [],
                     chemicalTests: []
                 };
 
-                // Compile Symptoms
                 symptomsContainer.querySelectorAll('.item-card').forEach(card => {
                     const name = card.querySelector('.symptom-name').value.trim();
                     const causes = card.querySelector('.symptom-causes').value.trim();
@@ -336,7 +362,6 @@
                     }
                 });
 
-                // Compile Questions
                 questionsContainer.querySelectorAll('.item-card').forEach(card => {
                     const text = card.querySelector('.question-text').value.trim();
                     const key = card.querySelector('.question-key').value.trim();
@@ -346,7 +371,6 @@
                     }
                 });
 
-                // Compile Tests
                 testsContainer.querySelectorAll('.item-card').forEach(card => {
                     const title = card.querySelector('.test-title').value.trim();
                     const description = card.querySelector('.test-description').value.trim();
@@ -360,7 +384,18 @@
                     }
                 });
 
-                // Create and trigger download
+                return finalData;
+            }
+
+            function updatePreview() {
+                const data = serializeData();
+                jsonPreview.textContent = JSON.stringify(data, null, 2);
+            }
+
+            // --- JSON Generation and Download ---
+            function generateAndDownloadJson() {
+                const finalData = serializeData();
+
                 const jsonString = JSON.stringify(finalData, null, 2); // Pretty print
                 const blob = new Blob([jsonString], { type: 'application/json' });
                 const url = URL.createObjectURL(blob);
@@ -372,9 +407,10 @@
                 document.body.removeChild(a);
                 URL.revokeObjectURL(url);
             }
-            
+
             // Show editor immediately for users starting from scratch
             editor.classList.remove('hidden');
+            updatePreview();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a JSON preview section that can be toggled open/closed
- serialize form fields and update preview whenever data changes
- ensure item removals also update the preview

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688e2a0c9df88321a2a012b22fdaba96