### PR TITLE
feat: centralize theme variables for light and dark mode

### DIFF
--- a/ContentsEditor.html
+++ b/ContentsEditor.html
@@ -5,21 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dishwasher Helper - Content Editor</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/theme.css">
     <style>
         /* Custom styles for a cleaner look */
         body {
-            background-color: #f7fafc;
+            background: var(--bg);
         }
         .card {
-            background-color: white;
+            background: var(--card);
             border-radius: 8px;
             box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
             margin-bottom: 1.5rem;
             overflow: hidden; /* Ensures child border-radius is respected */
         }
         .card-header {
-            background-color: #edf2f7;
-            border-bottom: 1px solid #e2e8f0;
+            background: var(--bg);
+            border-bottom: 1px solid var(--sep);
             padding: 1rem 1.5rem;
             font-weight: 600;
         }
@@ -27,7 +28,7 @@
             padding: 1.5rem;
         }
         .item-card {
-            border: 1px solid #e2e8f0;
+            border: 1px solid var(--sep);
             border-radius: 6px;
             margin-bottom: 1rem;
             position: relative;
@@ -39,8 +40,8 @@
             position: absolute;
             top: 0.5rem;
             right: 0.5rem;
-            background-color: #fed7d7;
-            color: #c53030;
+            background: var(--danger);
+            color: var(--on-accent);
             border-radius: 9999px;
             width: 1.75rem;
             height: 1.75rem;
@@ -48,10 +49,10 @@
             align-items: center;
             justify-content: center;
             cursor: pointer;
-            transition: background-color 0.2s;
+            transition: opacity 0.2s;
         }
         .delete-btn:hover {
-            background-color: #fbb6b6;
+            opacity: .9;
         }
         .btn {
             display: inline-block;
@@ -59,44 +60,51 @@
             border-radius: 6px;
             font-weight: 600;
             text-align: center;
-            transition: background-color 0.2s;
+            transition: opacity 0.2s;
             cursor: pointer;
         }
         .btn-primary {
-            background-color: #4299e1;
-            color: white;
+            background: var(--accent);
+            color: var(--on-accent);
         }
         .btn-primary:hover {
-            background-color: #3182ce;
+            opacity: .9;
         }
         .btn-secondary {
-            background-color: #48bb78;
-            color: white;
+            background: var(--success);
+            color: var(--on-accent);
         }
         .btn-secondary:hover {
-            background-color: #38a169;
+            opacity: .9;
         }
         .btn-disabled {
-            background-color: #a0aec0;
+            background: var(--sep);
             cursor: not-allowed;
+        }
+        input[type="file"]::file-selector-button {
+            background: color-mix(in srgb, var(--accent) 15%, var(--bg));
+            color: var(--accent);
+        }
+        input[type="file"]:hover::file-selector-button {
+            background: color-mix(in srgb, var(--accent) 30%, var(--bg));
         }
         input[type="text"], textarea {
             width: 100%;
             padding: 0.5rem;
-            border: 1px solid #cbd5e0;
+            border: 1px solid var(--sep);
             border-radius: 4px;
             transition: border-color 0.2s;
         }
         input[type="text"]:focus, textarea:focus {
             outline: none;
-            border-color: #4299e1;
-            box-shadow: 0 0 0 2px rgba(66, 153, 225, 0.5);
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent);
         }
         label {
             display: block;
             font-weight: 600;
             margin-bottom: 0.25rem;
-            color: #4a5568;
+            color: var(--muted);
         }
     </style>
 </head>
@@ -113,7 +121,7 @@
             <div class="card-header">Step 1: Load Your Data</div>
             <div class="card-body">
                 <p class="mb-4 text-gray-600">Upload your existing <code class="bg-gray-200 text-sm p-1 rounded">app_data.json</code> file to edit it. If you don't have one, you can start from scratch.</p>
-                <input type="file" id="fileUploader" accept=".json" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"/>
+                <input type="file" id="fileUploader" accept=".json" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold"/>
             </div>
         </div>
 

--- a/css/main.css
+++ b/css/main.css
@@ -1,20 +1,6 @@
-:root{
-  --bg:#f7f9fa;        --card:#ffffff; --txt:#222;
-  --accent:#0073e6;     --sep:rgba(0,0,0,.08);
-  --yes:#2e8b57;       --no:#c0392b;
-  --danger:#e74c3c;     --success:#2ecc71;
-}
-@media (prefers-color-scheme:dark){
-  :root{
-    --bg:#121417;      --card:#1e2125; --txt:#e0e3e6;
-    --accent:#53a2ff;  --sep:rgba(255,255,255,.08);
-    --yes:#2ecc71;     --no:#e74c3c;
-  }
-}
 *{box-sizing:border-box;margin:0;padding:0}
 body{
-  font-family:system-ui,-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
-  background:var(--bg);color:var(--txt);line-height:1.45;padding:1rem;
+  line-height:1.45;padding:1rem;
 }
 .wrapper{max-width:760px;margin:0 auto;}
 h1{margin:.2rem 0 .6rem}
@@ -31,7 +17,7 @@ select,button,input{
 }
 select,input{width:100%}
 button{
-  cursor:pointer;background:var(--accent);border-color:var(--accent);color:#fff;
+  cursor:pointer;background:var(--accent);border-color:var(--accent);color:var(--on-accent);
   transition:opacity .18s;width:100%
 }
 button:hover{opacity:.9}
@@ -53,8 +39,8 @@ button:hover{opacity:.9}
   padding:.34rem .95rem;font-size:.92rem;cursor:pointer;transition:opacity .15s;opacity:.4
 }
 .toggle input:checked+label{opacity:1}
-.toggle .yes{background:var(--yes);color:#fff}
-.toggle .no {background:var(--no);color:#fff}
+.toggle .yes{background:var(--yes);color:var(--on-accent)}
+.toggle .no {background:var(--no);color:var(--on-accent)}
 .note{flex:1 1 100%;margin:.4rem 0 0;font-size:.85rem;color:var(--accent)}
 .mm-row{display:flex;gap:.6rem;flex-wrap:wrap;margin-bottom:1rem}
 .mm-row div{flex:1 1 200px}
@@ -64,5 +50,5 @@ button:hover{opacity:.9}
 #chemTestsList strong{display:block;margin-bottom:.3rem}
 @media print{
   #copyBtn,#essBar a{display:none!important}
-  body{background:#fff}
+  body{background:var(--card)}
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,0 +1,48 @@
+:root {
+  --bg: #f7f9fa;
+  --card: #ffffff;
+  --txt: #222;
+  --muted: #4a5568;
+  --accent: #0073e6;
+  --sep: rgba(0, 0, 0, 0.08);
+  --yes: #2e8b57;
+  --no: #c0392b;
+  --danger: #e74c3c;
+  --success: #2ecc71;
+  --on-accent: #ffffff;
+  --font-body: system-ui,-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  --spacing: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121417;
+    --card: #1e2125;
+    --txt: #e0e3e6;
+    --muted: #a0aec0;
+    --accent: #53a2ff;
+    --sep: rgba(255, 255, 255, 0.08);
+    --yes: #2ecc71;
+    --no: #e74c3c;
+  }
+}
+
+body {
+  background: var(--bg);
+  color: var(--txt);
+  font-family: var(--font-body);
+}
+
+.text-gray-800,
+.text-gray-700 {
+  color: var(--txt);
+}
+
+.text-gray-600,
+.text-gray-500 {
+  color: var(--muted);
+}
+
+.bg-gray-200 {
+  background: var(--card);
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Dishwasher Troubleshooting</title>
+<link rel="stylesheet" href="css/theme.css">
 <link rel="stylesheet" href="css/main.css">
 <link rel="manifest">
 </head>


### PR DESCRIPTION
## Summary
- add `theme.css` defining color, font and spacing variables with dark-mode overrides
- import shared theme into `index.html` and `ContentsEditor.html`
- refactor page styles to consume theme variables for cards, buttons and inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2a0dbef88321beb7278d85e1e7c5